### PR TITLE
glibc-sourcery: forcibly rebuild to work-around the Quark x1000 Segfa…

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -40,3 +40,7 @@ PACKAGE_EXTRA_ARCHS_append = " intel-quark quark i586 x86"
 
 EXTRA_IMAGEDEPENDS_append = " acpi-upgrades"
 INITRD_LIVE_prepend = "${DEPLOY_DIR_IMAGE}/acpi-upgrades-${MACHINE}.cpio "
+
+# glibc needs to be compiled with -Wa,-momit-lock-prefix for the iot2000 BSP
+# force a rebuild with the following TCMODE setting
+TCMODE = "external-sourcery-rebuild-libc"

--- a/meta-iot2000-bsp/recipes-external/glibc/glibc-sourcery.bbappend
+++ b/meta-iot2000-bsp/recipes-external/glibc/glibc-sourcery.bbappend
@@ -1,0 +1,14 @@
+# location of the CodeBench sources
+SOURCERY_BASE_URI = "ftp://ftpnew.alm.mentorg.com/pub/CodeBench/Released/Offline_Installers"
+SOURCERY_SRC_FILE = "codebench-sources-2017.02-55-i686-pc-linux-gnu.tar.bz2"
+SOURCERY_SRC_URI  = "${SOURCERY_BASE_URI}/2017.02/IA32/${SOURCERY_SRC_FILE}"
+
+# source tarball checksums
+SRC_URI[md5sum]    = "4069cc767890a2ae8773c0440a198c24"
+SRC_URI[sha256sum] = "105e99ee8260b4e4602b908734e503a21b9acad71fb45476b677867e5c6af615"
+
+# we need to extract scb-toolchain to get the glibc source tarball
+unpack_libc_prepend () {
+    tar jxf scb-2017.*/scb-toolchain-*.tar.bz2
+}
+


### PR DESCRIPTION
…ult bug

glibc needs to be rebuilt with LOCK instructions omitted from the generated
code. Amend the glibc-sourcery recipe to get the toolchain source tarballs
from our internal file servers

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>