### PR TITLE
swupdate_%.bbappend

### DIFF
--- a/meta-iot2000-bsp/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-iot2000-bsp/recipes-support/swupdate/swupdate_%.bbappend
@@ -10,7 +10,7 @@ SRC_URI += " \
      file://swupdate-env \
      "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "5810b5ec5d4fab56503dc99abd264d1ba196ce11"
 
 do_install_append() {
     install -d ${D}${bindir}


### PR DESCRIPTION
Upstream has changed the Makefile in an an incompatible way.  meta-swupdate will need to be updated to fix this.  In the meantime, pin the version against an older working version of swupdate.