### PR TITLE
machine/iot2000: no longer set IMAGE_LINGUAS

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -48,10 +48,6 @@ TCMODE = "external-sourcery-rebuild-libc"
 ENABLE_BINARY_LOCALE_GENERATION = "1"
 GLIBC_INTERNAL_USE_BINARY_LOCALE = "compile"
 
-# Unfortunately a single binary locale package gets generated, we will want that
-# one used in our images
-IMAGE_LINGUAS = "en-us.iso-8859-1"
-
 # Generate compressed EXT4 images for swupdate
 IMAGE_FSTYPES += " ext4.gz"
 


### PR DESCRIPTION
It is no longer necessary to force use of a locale, the BSP is now
building just fine with the default setting.

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>