### PR TITLE
machine/iot2000: remove settings to rebuild glibc from source

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -41,13 +41,6 @@ PACKAGE_EXTRA_ARCHS_append = " intel-quark quark i586 x86"
 EXTRA_IMAGEDEPENDS_append = " acpi-upgrades"
 INITRD_LIVE_prepend = "${DEPLOY_DIR_IMAGE}/acpi-upgrades-${MACHINE}.cpio "
 
-# glibc needs to be compiled with -Wa,-momit-lock-prefix for the iot2000 BSP
-# force a rebuild with the following TCMODE setting and also get binary locales
-# compiled
-TCMODE = "external-sourcery-rebuild-libc"
-ENABLE_BINARY_LOCALE_GENERATION = "1"
-GLIBC_INTERNAL_USE_BINARY_LOCALE = "compile"
-
 # Generate compressed EXT4 images for swupdate
 IMAGE_FSTYPES += " ext4.gz"
 

--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -48,10 +48,6 @@ TCMODE = "external-sourcery-rebuild-libc"
 ENABLE_BINARY_LOCALE_GENERATION = "1"
 GLIBC_INTERNAL_USE_BINARY_LOCALE = "compile"
 
-# Unfortunately a single binary locale package gets generated, we will want that
-# one used in our images
-IMAGE_LINGUAS = "en-us.iso-8859-1"
-
 # Generate compressed EXT4 images for swupdate
 IMAGE_FSTYPES += " ext4.gz"
 


### PR DESCRIPTION
MEL used to ship a pre-built version of the glibc library. This was an issue on the
iot2000 as it has to be compiled with a special compiler flag (-Wa,-no-lock-prefix)
to work-around a hardware bug with the Intel Quark processor. To address this issue,
the meta-iot2000-bsp layer was instructing MEL to rebuild glibc from source (and use
the aforementioned compiler flag). Starting with MEL 2017.02 Update 2, glibc is
always built from source and our changes in meta-iot2000-bsp are no longer required
(reducing the gap with upstream)

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>