### PR TITLE
Initial commit of sw-descritpion file for compound image and added bz…

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -49,3 +49,5 @@ IMAGE_FSTYPES += " ext4.gz"
 
 MACHINE_FEATURES += "swupdate"
 IMAGE_FSTYPES += "${@bb.utils.contains('COMBINED_FEATURES', 'swupdate', 'ext4.swu', '', d)}"
+
+MACHINE_BOOT_FILES = "bzImage"

--- a/meta-iot2000-bsp/files/iot2000/compound/sw-description.bbin
+++ b/meta-iot2000-bsp/files/iot2000/compound/sw-description.bbin
@@ -1,0 +1,70 @@
+software =
+{
+        version = "1.0";
+        hardware-compatibility = [ "1.0" ];
+        stable:
+        {
+                platform0:
+                {
+                        images: (
+                        {
+                                filename = "${image}";
+                                sha256 = "@${image}";
+                                device = "/dev/mmcblk0p2";
+				compressed = true;
+                        },
+			{
+				filename = "bzImage"
+				sha256 = "@bzImage"
+				path = "/run/media/BOOT0"
+				type = "rawfile"
+			}
+                        );
+			bootenv: (
+                        {
+                                name = "testing";
+                                value = "1";
+                        },
+                        {
+                                name = "kernelfile";
+                                value = "C:BOOT0:bzImage";
+                        },
+                        {
+                                name = "kernelparams";
+                                value = "root=/dev/mmcblk0p2 console=ttyS1,115200n8 reboot=efi,warm rw debugshell=5 rootwait initrd=acpi-upgrades-iot2000.cpio";
+                        }
+                        );
+                };
+                platform1:
+                {
+                        images: (
+                        {
+                                filename = "${image}";
+                                sha256 = "@${image}";
+                                device = "/dev/mmcblk0p3";
+				compressed = true;
+                        },
+                        {
+                                filename = "bzImage"
+                                sha256 = "@bzImage"
+                                path = "/run/media/BOOT1"
+                                type = "rawfile"
+                        }
+			);
+			bootenv: (
+                        {
+                                name = "testing";
+                                value = "1";
+                        },
+                        {
+                                name = "kernelfile";
+                                value = "C:BOOT1:bzImage";
+                        },
+                        {
+                                name = "kernelparams";
+                                value = "root=/dev/mmcblk0p3 console=ttyS1,115200n8 reboot=efi,warm rw debugshell=5 rootwait initrd=acpi-upgrades-iot2000.cpio";
+                        }
+                        );
+                };
+        };
+}


### PR DESCRIPTION
…Image in MACHINE_BOOT_FILES.

* Added initial commit of sw-description file for compound image. Further bzImage
  needs to be added in MACHINE_BOOT_FILES so that it can be picked in
  IMAGE_BOOT_FILES = "${MACHINE_BOOT_FILES} when set in local.conf while building
  with meta-mentor-swupdate.

Signed-off-by: Noor Ahsan <noor_ahsan@mentor.com>