### PR TITLE
iot2000/sw-description.bbin: stream image without temporary copy

### DIFF
--- a/meta-iot2000-bsp/files/iot2000/sw-description.bbin
+++ b/meta-iot2000-bsp/files/iot2000/sw-description.bbin
@@ -13,6 +13,7 @@ software =
                                 device = "/dev/mmcblk0p2";
                                 compressed = false;
                                 encrypted = @${image}-status;
+                                installed-directly = true;
                         }
                         );
                         bootenv: (
@@ -39,6 +40,7 @@ software =
                                 device = "/dev/mmcblk0p3";
                                 compressed = false;
                                 encrypted = @${image}-status;
+                                installed-directly = true;
                         }
                         );
                         bootenv: (


### PR DESCRIPTION
We have limited tmp space on IoT2020 target board and image size
larger than tmp space fails with:
Failed writing received data to disk/application
So use installed-directly to stream image without creating a temp
copy.

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>