### PR TITLE
swupdate: determine whether update was successful

### DIFF
--- a/meta-iot2000-bsp/recipes-support/swupdate/swupdate/swupdate-env
+++ b/meta-iot2000-bsp/recipes-support/swupdate/swupdate/swupdate-env
@@ -2,6 +2,28 @@
 
 # Determine root partition (assumes "root" is the first kernel option)
 rootpart=$(cat /proc/cmdline|sed -e 's,^root=/dev/mmcblk0p\([23]\) .*,\1,g')
+rm -f /run/media/persistent/swupdate_flags/update_status
+
+if [ ! -d "/run/media/persistent/swupdate_flags" ]; then
+  mkdir /run/media/persistent/swupdate_flags
+fi
+
+if [ -e "/run/media/persistent/swupdate_flags/update_performed" ]; then
+  prevpart=`cat /run/media/persistent/swupdate_flags/prevpart`
+
+  if [ "$rootpart" != "$prevpart" ]; then
+    update_status="2"
+    bg_setenv -c
+  else
+    update_status="3"
+  fi
+  rm -f /run/media/persistent/swupdate_flags/update_performed
+else
+  update_status=""
+fi
+
+echo -n "$rootpart" > /run/media/persistent/swupdate_flags/prevpart
+echo -n "$update_status" > /run/media/persistent//swupdate_flags/update_status
 
 case "${rootpart}" in
    2) PLATFORM_ID=platform1;;
@@ -28,5 +50,5 @@ done
 cat >/tmp/swupdate.env <<EOF
 MACHINE_ID=${MACHINE_ID}
 PLATFORM_ID=${PLATFORM_ID}
+UPDATE_STATUS=${update_status}
 EOF
-

--- a/meta-iot2000-bsp/recipes-support/swupdate/swupdate/swupdate.service.in
+++ b/meta-iot2000-bsp/recipes-support/swupdate/swupdate/swupdate.service.in
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 ExecStartPre=-/usr/bin/swupdate-env
 EnvironmentFile=-/tmp/swupdate.env
-ExecStart=/usr/bin/swupdate -u "-c 2 -t default -u @hawkbit_url@ -i ${MACHINE_ID}" -p /sbin/reboot -e stable,${PLATFORM_ID}
+ExecStart=/usr/bin/swupdate -u "-c ${UPDATE_STATUS} -t default -u @hawkbit_url@ -i ${MACHINE_ID}" -p "touch /run/media/persistent/swupdate_flags/update_performed /sbin/reboot" -e stable,${PLATFORM_ID}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Instead of sending hawkbit server hardcoded success status, determine
whether update was successful. Based on that send status to hawkbit
server.

Signed-off-by: Fahad Arslan <Fahad_Arslan@mentor.com>