### PR TITLE
wic-image.iot2000.wks: fix platform label

### DIFF
--- a/meta-iot2000-bsp/scripts/lib/wic/canned-wks/wic-image.iot2000.wks
+++ b/meta-iot2000-bsp/scripts/lib/wic/canned-wks/wic-image.iot2000.wks
@@ -7,7 +7,7 @@ part --source efibootguard-efi --size 32 --extra-space 0 --overhead-factor 1 --o
 
 # Two root partitions for updateability, leave away 2nd if not used
 part / --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform0 --align 1024
-part --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label plaftorm1 --align 1024
+part --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform1 --align 1024
 
 # Two config partitions to load boot configuration and kernel
 part --source efibootguard-boot --size 32 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --label boot0 --align 1024 --part-type=0700 --sourceparams "watchdog=60,revision=2"


### PR DESCRIPTION
A typo caused the label for 'platform1' to be 'plaftorm1'.

Signed-off-by: Benjamin Walsh <Benjamin_Walsh@mentor.com>