### PR TITLE
meta-iot2000-bsp: add support for user-data

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -20,7 +20,7 @@ PREFERRED_VERSION_linux-yocto-rt = "4.4%"
 #Avoid pulling in GRUB
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = ""
 
-MACHINE_FEATURES = "efi usb"
+MACHINE_FEATURES = "efi usb user-data"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 

--- a/meta-iot2000-bsp/recipes-core/images/wic-image.inc
+++ b/meta-iot2000-bsp/recipes-core/images/wic-image.inc
@@ -1,5 +1,5 @@
 IMAGE_FSTYPES_append_iot2000 = " wic wic.bmap"
 
-WKS_FILE = "wic-image.${MACHINE}.wks"
+WKS_FILE = "wic-image.${MACHINE}.wks.in"
 
 require recipes-core/images/acpi-upgrades.inc

--- a/meta-iot2000-bsp/scripts/lib/wic/canned-wks/wic-image.iot2000.wks.in
+++ b/meta-iot2000-bsp/scripts/lib/wic/canned-wks/wic-image.iot2000.wks.in
@@ -6,8 +6,8 @@
 part --source efibootguard-efi --size 32 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --label efi --part-type=EF00 --align 1024
 
 # Two root partitions for updateability, leave away 2nd if not used
-part / --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform --align 1024
-part   --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform --align 1024
+part / --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform --align 1024 --use-uuid
+part   --source rootfs --size 2048 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label platform --align 1024 --use-uuid
 
 # Two config partitions to load boot configuration and kernel
 part --source efibootguard-boot --size 32 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --label boot0 --align 1024 --part-type=0700 --sourceparams "watchdog=60,revision=2"
@@ -15,6 +15,7 @@ part --source efibootguard-boot --size 32 --extra-space 0 --overhead-factor 1 --
 
 # Other partitions
 part --size 1024 --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --label persistent --align 1024 --fstype=ext4
+${@bb.utils.contains('COMBINED_FEATURES', 'user-data', 'part %s --extra-space 0 --overhead-factor 1 --ondisk mmcblk0 --fstype=ext4 --label data --align 1024 --size %s --use-uuid' % (d.getVar('USER_DATA_MOUNT', True), d.getVar('USER_DATA_SIZE', True)), '', d)}
 part swap --ondisk mmcblk0 --size 512 --fstype=swap --label swap --align 1024
 
 # Important for type of partition table


### PR DESCRIPTION
The iot2000 BSP did not include user-data persistent data on a read-only
rootfs as some of our other BSPs do.  Add in support for this feature,
modelled on the MF0200 approach, and store /var/lib (where docker
containers and the package management database are store) to the persistent
data area.

Signed-off-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>